### PR TITLE
Fix migration stubs

### DIFF
--- a/stubs/stubs/migration.create.stub
+++ b/stubs/stubs/migration.create.stub
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class {{ class }} extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -20,4 +20,4 @@ class {{ class }} extends Migration
     {
         Schema::dropIfExists('{{ table }}');
     }
-}
+};

--- a/stubs/stubs/migration.stub
+++ b/stubs/stubs/migration.stub
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class {{ class }} extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -17,4 +17,4 @@ class {{ class }} extends Migration
     {
         //
     }
-}
+};

--- a/stubs/stubs/migration.update.stub
+++ b/stubs/stubs/migration.update.stub
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class {{ class }} extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -21,4 +21,4 @@ class {{ class }} extends Migration
             //
         });
     }
-}
+};


### PR DESCRIPTION
Hi.

It,s my first ever pull request, so be indulgent.....

Ok, trying to make a new migration with artisan  results in a failing migration file. For example, creating a frame table we got this:

`class {{ class }} extends Migration
{
    public function up()
    {
        Schema::create('frames', function (Blueprint $table) {
            $table->id();
            $table->timestamps();
        });
    }`

There was a change in laravel/framework and the stubs in this repository are still the old ones. Here you got more (and better) information.

[https://github.com/laravel/framework/pull/37352](url)

Ok, that is. 

Best regards and thanks for your work 